### PR TITLE
Fix stock validation in cart service

### DIFF
--- a/apps/server/src/cart/services/cart.service.ts
+++ b/apps/server/src/cart/services/cart.service.ts
@@ -49,6 +49,10 @@ export class CartService {
     const product = await this.productsService.findById(productId);
     if (!product) throw new NotFoundException('Product not found');
 
+    if (qty > product.countInStock) {
+      throw new BadRequestException('Not enough stock');
+    }
+
     const cart = await this.getCart(user);
     const existingItem = cart.items.find(
       item => item.productId.toString() === productId,


### PR DESCRIPTION
## Summary
- prevent adding more items to cart than are in stock

## Testing
- `npm test --silent` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684349303d6083318749a569c6a846ef